### PR TITLE
Selected btn color, quantstamp link icon and css fixes

### DIFF
--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -31,7 +31,7 @@ const CurrencySelect = styled.button<{ selected: boolean; primary?: boolean; lef
   font-weight: 500;
   background-color: ${({ selected, primary, theme }) => {
     if (selected) {
-      return theme.bg4
+      return theme.bg7
     } else {
       if (primary) {
         return theme.bg6
@@ -55,7 +55,7 @@ const CurrencySelect = styled.button<{ selected: boolean; primary?: boolean; lef
   :hover {
     background-color: ${({ selected, primary, theme }) => {
       if (selected) {
-        return theme.bg4
+        return theme.bg7
       } else {
         if (primary) {
           return theme.bg6

--- a/src/components/NavigationTabs/index.tsx
+++ b/src/components/NavigationTabs/index.tsx
@@ -40,7 +40,7 @@ const StyledNavLink = styled(NavLink).attrs({
   font-size: 20px;
   padding: 30px;
   &.${activeClassName} {
-    background-color: #135ce3;
+    background-color:${({ theme }) => theme.bg7};
     color: ${({ theme }) => theme.text1};
   }
   :hover,

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -27,6 +27,8 @@ import PreviewListing from './PreviewListing'
 
 import Analyze from './Analyze'
 
+import { ExternalLink } from 'react-feather'
+
 const AppWrapper = styled.div`
   display: flex;
   flex-flow: column;
@@ -70,17 +72,24 @@ const FooterWrapper = styled.div`
   bottom: 0;
   width: 100%;
   text-align: center;
-  background-color: #2b3a4a;
   z-index: 1;
   padding: 5px 0;
-
+  background-color: #2b3a4a;
   a {
+    text-decoration:none;
     color: ${({ theme }) => theme.text1};
     :hover,
     :focus {
-      text-decoration: none;
+      text-decoration: underline;
     }
   }
+`
+
+const NewWindowIcon = styled.div`
+  position: absolute;
+  top: 6px;
+  display: inline-block;
+  margin-left: 5px;
 `
 
 export default function App() {
@@ -119,7 +128,7 @@ export default function App() {
           </BodyWrapper>
           <FooterWrapper>
             <a target="_blank" rel="noopener noreferrer" href="https://certificate.quantstamp.com/full/linkswap">
-              Quantstamp Audit Report - LINKSWAP
+              Quantstamp Audit Report - LINKSWAP <NewWindowIcon><ExternalLink size='15' color='white' /></NewWindowIcon>
             </a>
           </FooterWrapper>
         </AppWrapper>

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -74,7 +74,7 @@ const FooterWrapper = styled.div`
   text-align: center;
   z-index: 1;
   padding: 5px 0;
-  background-color: ${({ theme }) => theme.bg8};
+  background-color: ${({ theme }) => theme.bodyBackground};
   a {
     text-decoration:none;
     color: ${({ theme }) => theme.text1};

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -74,7 +74,7 @@ const FooterWrapper = styled.div`
   text-align: center;
   z-index: 1;
   padding: 5px 0;
-  background-color: #2b3a4a;
+  background-color: ${({ theme }) => theme.bg8};
   a {
     text-decoration:none;
     color: ${({ theme }) => theme.text1};

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -327,7 +327,7 @@ export default function Swap() {
                       onSwitchTokens()
                       setInversed(!inversed)
                     }}
-                    color={currencies[Field.INPUT] && currencies[Field.OUTPUT] ? theme.primary1 : theme.text2}
+                    color={currencies[Field.INPUT] && currencies[Field.OUTPUT] ? theme.primary1 : theme.text1}
                   />
                 </ArrowWrapper>
                 {recipient === null && !showWrap && isExpertMode ? (

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -60,7 +60,7 @@ export function colors(darkMode: boolean): Colors {
     bg5: darkMode ? '#6C7284' : '#888D9B',
     bg6: darkMode ? '#373F49' : '#FFFFFF',
     bg7: '#135ce3',
-    bg8: '#2b3a4a',
+    bodyBackground: '#2b3a4a',
     //specialty colors
     modalBG: darkMode ? 'rgba(0,0,0,.425)' : 'rgba(0,0,0,0.3)',
     advancedBG: darkMode ? 'rgba(0,0,0,0.1)' : 'rgba(255,255,255,0.6)',
@@ -220,5 +220,5 @@ body {
   background-image: url("https://yflink.io/YFL-BG-pattern-left.svg");
   background-position: 0 10vh;
   background-repeat: no-repeat;
-  background-color: #2B3A4A;
+  background-color:  ${({ theme }) => theme.bodyBackground};
 `

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -60,6 +60,7 @@ export function colors(darkMode: boolean): Colors {
     bg5: darkMode ? '#6C7284' : '#888D9B',
     bg6: darkMode ? '#373F49' : '#FFFFFF',
     bg7: '#135ce3',
+    bg8: '#2b3a4a',
     //specialty colors
     modalBG: darkMode ? 'rgba(0,0,0,.425)' : 'rgba(0,0,0,0.3)',
     advancedBG: darkMode ? 'rgba(0,0,0,0.1)' : 'rgba(255,255,255,0.6)',

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -21,7 +21,7 @@ const MEDIA_WIDTHS = {
 
 const mediaWidthTemplates: { [width in keyof typeof MEDIA_WIDTHS]: typeof css } = Object.keys(MEDIA_WIDTHS).reduce(
   (accumulator, size) => {
-    ;(accumulator as any)[size] = (a: any, b: any, c: any) => css`
+    ; (accumulator as any)[size] = (a: any, b: any, c: any) => css`
       @media (max-width: ${(MEDIA_WIDTHS as any)[size]}px) {
         ${css(a, b, c)}
       }
@@ -59,6 +59,7 @@ export function colors(darkMode: boolean): Colors {
     bg4: darkMode ? '#5F656D' : '#CED0D9',
     bg5: darkMode ? '#6C7284' : '#888D9B',
     bg6: darkMode ? '#373F49' : '#FFFFFF',
+    bg7: '#135ce3',
     //specialty colors
     modalBG: darkMode ? 'rgba(0,0,0,.425)' : 'rgba(0,0,0,0.3)',
     advancedBG: darkMode ? 'rgba(0,0,0,0.1)' : 'rgba(255,255,255,0.6)',
@@ -127,7 +128,7 @@ export default function ThemeProvider({ children }: { children: React.ReactNode 
   return <StyledComponentsThemeProvider theme={themeObject}>{children}</StyledComponentsThemeProvider>
 }
 
-const TextWrapper = styled(Text)<{ color: keyof Colors }>`
+const TextWrapper = styled(Text) <{ color: keyof Colors }>`
   color: ${({ color, theme }) => (theme as any)[color]};
 `
 

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -21,6 +21,7 @@ export interface Colors {
   bg5: Color
   bg6: Color
   bg7: Color
+  bg8: Color
 
   modalBG: Color
   advancedBG: Color

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -20,6 +20,7 @@ export interface Colors {
   bg4: Color
   bg5: Color
   bg6: Color
+  bg7: Color
 
   modalBG: Color
   advancedBG: Color

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -21,7 +21,7 @@ export interface Colors {
   bg5: Color
   bg6: Color
   bg7: Color
-  bg8: Color
+  bodyBackground: Color
 
   modalBG: Color
   advancedBG: Color


### PR DESCRIPTION
Changed the background color of the selected currency to "#135ce3" for a cleaner look and to be clear which one is selected.
From the advice of discord user Linkie Link#1393, I've added this as bg7 in the theme. 
The color is the same for both dark and light mode.

For the Quantstamp link, I have added the ExternalLink icon and removed the underline style, again, for a cleaner look and also to make it clear that it is a link.