### PR TITLE
exclude YFL address from warning message and remove some console.log …

### DIFF
--- a/src/data/Reserves.ts
+++ b/src/data/Reserves.ts
@@ -31,17 +31,10 @@ export function usePairs(currencies: [Currency | undefined, Currency | undefined
   const pairAddresses = useMemo(
     () =>
       tokens.map(([tokenA, tokenB]) => {
-        console.log('zaza')
-        if (tokenA && tokenB) {
-          console.log(Pair.getAddress(tokenA, tokenB))
-        }
         return tokenA && tokenB && !tokenA.equals(tokenB) ? Pair.getAddress(tokenA, tokenB) : undefined
       }),
     [tokens]
   )
-
-  console.log('zaza')
-  console.log(pairAddresses)
 
   const results = useMultipleContractSingleData(pairAddresses, PAIR_INTERFACE, 'getReserves')
 

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -47,6 +47,8 @@ import { useTranslation } from 'react-i18next'
 export default function Swap() {
   const loadedUrlParams = useDefaultsFromURLSearch()
 
+  const yflAddress = "0x28cb7e841ee97947a86B06fA4090C8451f64c0be";
+
   const [inversed, setInversed] = useState(false)
 
   // token warning stuff
@@ -56,7 +58,7 @@ export default function Swap() {
   ]
   const [dismissTokenWarning, setDismissTokenWarning] = useState<boolean>(false)
   const urlLoadedTokens: Token[] = useMemo(
-    () => [loadedInputCurrency, loadedOutputCurrency]?.filter((c): c is Token => c instanceof Token) ?? [],
+    () => [loadedInputCurrency, loadedOutputCurrency]?.filter((c): c is Token => c instanceof Token && c.address !== yflAddress) ?? [],
     [loadedInputCurrency, loadedOutputCurrency]
   )
   const handleConfirmTokenWarning = useCallback(() => {


### PR DESCRIPTION
this change removes the modal window for YFL that warns the user about unknown token
this is especially annoying as there is a direct link to https://linkswap.app/#/swap?outputCurrency=0x28cb7e841ee97947a86b06fa4090c8451f64c0be on all pages

the solution implemented is a "quick fix", very "bad" as an implementation
probably the much better one would be to iterate over the json from DEFAULT_TOKEN_LIST_URL and see if the token address is in that list or not
