### PR TITLE
Change UNI-V2 to LSLP in recent transactions

### DIFF
--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -165,7 +165,7 @@ export function usePairAdder(): (pair: Pair) => void {
  * @param tokenB the other token
  */
 export function toV2LiquidityToken([tokenA, tokenB]: [Token, Token]): Token {
-  return new Token(tokenA.chainId, Pair.getAddress(tokenA, tokenB), 18, 'UNI-V2', 'Uniswap V2')
+  return new Token(tokenA.chainId, Pair.getAddress(tokenA, tokenB), 18, 'LSLP', 'LINKSWAP LP Token (LSLP)')
 }
 
 /**


### PR DESCRIPTION
This PR changes UNI-V2 to LSLP when viewing LSLP tokens in recent transactions.